### PR TITLE
add fedora to dependency installer

### DIFF
--- a/install_deps
+++ b/install_deps
@@ -23,4 +23,6 @@ elif [ "$OS" = "Alpine Linux" ]; then
 elif [ "$OS" = "Iglunix" ]; then
 	iglu add wayland-protocols libudev-zero libinput wayland libdrm seatd
 	echo "At the moment please manually install xkbcommon from iglupkg"
+elif [ "$OS" = "Fedora Linux" ] || [ -f /etc/redhat-release ]; then
+	dnf install wayland-devel libseat-devel libinput-devel libpng-devel libglvnd-devel systemd-devel libxkbcommon-devel libdrm-devel mesa-libgbm-devel
 fi


### PR DESCRIPTION
+ added fedora dependencies to installer
+ tested on fedora 40, working.

note: red hat enterprise linux 9 complains about not being able to find `libinput-devel` and `libseat-devel`, it is highly possible that the dependency list for fedora won't work for RHEL & CentOS & AlmaLinux & RockyLinux.